### PR TITLE
SRV-131 Fix empty dataset result of publisher stats

### DIFF
--- a/src/Publisher/Dto/StatsResult.php
+++ b/src/Publisher/Dto/StatsResult.php
@@ -24,7 +24,7 @@ namespace Adshares\Publisher\Dto;
 
 class StatsResult
 {
-    private $data;
+    private $data = [];
 
     public function __construct(array $inputData)
     {


### PR DESCRIPTION
It is equivalent of `SRV-144 Fix empty dataset from stats repo (#330)` on publisher side.