### PR TITLE
Fix test paid events processing

### DIFF
--- a/tests/app/Services/PaymentDetailsProcessorTest.php
+++ b/tests/app/Services/PaymentDetailsProcessorTest.php
@@ -96,11 +96,9 @@ final class PaymentDetailsProcessorTest extends TestCase
         }
         $expectedAdIncome = $totalPayment - $expectedLicenseAmount - $expectedOperatorAmount;
 
+        $this->assertEquals($totalPayment, $result->eventValuePartialSum());
         $this->assertEquals($expectedLicenseAmount, $result->licenseFeePartialSum());
-
-        $this->assertCount(1, UserLedgerEntry::all());
-        $userLedgerEntry = UserLedgerEntry::first();
-        $this->assertEquals($expectedAdIncome, $userLedgerEntry->amount);
+        $this->assertEquals($expectedAdIncome, NetworkEventLog::sum('paid_amount'));
     }
 
     private function getExchangeRateReader(): ExchangeRateReader


### PR DESCRIPTION
PaymentDetailsProcess does not assign income to user ledger, only updates events' paid_amount