### PR TITLE
Add missing description for commands

### DIFF
--- a/app/Console/Commands/AdPayGetPayments.php
+++ b/app/Console/Commands/AdPayGetPayments.php
@@ -50,6 +50,8 @@ class AdPayGetPayments extends BaseCommand
 
     protected $signature = 'ops:adpay:payments:get {--t|timestamp=} {--s|sub=1} {--f|force} {--c|chunkSize=250}';
 
+    protected $description = 'Updates events with payment data fetched from adpay';
+
     public function handle(AdPay $adPay, ExchangeRateReader $exchangeRateReader): void
     {
         if (!$this->lock()) {

--- a/app/Console/Commands/AdsMe.php
+++ b/app/Console/Commands/AdsMe.php
@@ -27,6 +27,8 @@ class AdsMe extends BaseCommand
 {
     protected $signature = 'ads:me';
 
+    protected $description = 'Prints adserver blockchain account balance';
+
     public function handle(AdsClient $adsClient)
     {
         if (!$this->lock()) {

--- a/app/Console/Commands/AdsSend.php
+++ b/app/Console/Commands/AdsSend.php
@@ -33,6 +33,8 @@ class AdsSend extends BaseCommand
 {
     protected $signature = 'ads:send {--external}';
 
+    protected $description = 'For testing purposes: sends ads to seeded accounts';
+
     /** @var array */
     private $data = [];
 

--- a/app/Console/Commands/DemandBlockRequiredAmount.php
+++ b/app/Console/Commands/DemandBlockRequiredAmount.php
@@ -38,6 +38,8 @@ class DemandBlockRequiredAmount extends BaseCommand
 {
     protected $signature = 'ops:demand:payments:block';
 
+    protected $description = 'Reserves user funds for payment for campaign events';
+
     /** @var ExchangeRateReader */
     private $exchangeRateReader;
 

--- a/app/Console/Commands/DemandPreparePayments.php
+++ b/app/Console/Commands/DemandPreparePayments.php
@@ -33,6 +33,8 @@ class DemandPreparePayments extends BaseCommand
 {
     protected $signature = 'ops:demand:payments:prepare {--c|chunkSize=10000}';
 
+    protected $description = 'Prepares payments for events and license';
+
     /** @var LicenseReader */
     private $licenseReader;
 

--- a/app/Console/Commands/DemandSendPayments.php
+++ b/app/Console/Commands/DemandSendPayments.php
@@ -29,6 +29,8 @@ class DemandSendPayments extends BaseCommand
 {
     protected $signature = 'ops:demand:payments:send';
 
+    protected $description = 'Sends payments to supply adservers and license server';
+
     public function handle(Ads $ads): void
     {
         if (!$this->lock()) {

--- a/app/Console/Commands/UpdateFilteringOptions.php
+++ b/app/Console/Commands/UpdateFilteringOptions.php
@@ -26,6 +26,8 @@ class UpdateFilteringOptions extends BaseCommand
 {
     protected $signature = 'ops:filtering-options:update';
 
+    protected $description = 'Updates site filtering options';
+
     public function handle(FilteringOptionsImporter $service): void
     {
         if (!$this->lock()) {

--- a/app/Console/Commands/UpdateTargetingOptions.php
+++ b/app/Console/Commands/UpdateTargetingOptions.php
@@ -26,6 +26,8 @@ class UpdateTargetingOptions extends BaseCommand
 {
     protected $signature = 'ops:targeting-options:update';
 
+    protected $description = 'Updates campaign targeting options';
+
     public function handle(TargetingOptionsImporter $service): void
     {
         if (!$this->lock()) {


### PR DESCRIPTION
There were `This method should be used for inheritance only` description instead.