### PR TITLE
Add bid strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bid strategies
 - Storing sites' information (page rank) in database
 - Setting panel placeholders with an e-mail notification
+- Rejecting site's domains
+### Changed
+- Do not allow site's domain starts with a dot
 ### Removed
 - AdUser url from find.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rejecting site's domains
 ### Changed
 - Do not allow site's domain starts with a dot
+### Fixed
+- Retry ads transaction after error while processing demand payments
 ### Removed
 - AdUser url from find.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Bid strategies
 - Storing sites' information (page rank) in database
 - Setting panel placeholders with an e-mail notification
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storing sites' information (page rank) in database
 - Setting panel placeholders with an e-mail notification
 - Rejecting site's domains
+- Send an email notification once the banner was classified
 ### Changed
 - Do not allow site's domain starts with a dot
 ### Fixed

--- a/app/Client/GuzzleAdPayClient.php
+++ b/app/Client/GuzzleAdPayClient.php
@@ -35,6 +35,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class GuzzleAdPayClient implements AdPay
 {
+    private const URI_BID_STRATEGIES = '/api/v1/bid-strategies';
+
     private const URI_CAMPAIGNS = '/api/v1/campaigns';
 
     private const URI_PAYMENTS_TEMPLATE = '/api/v1/payments/%d';
@@ -51,6 +53,28 @@ class GuzzleAdPayClient implements AdPay
     public function __construct(Client $client)
     {
         $this->client = $client;
+    }
+
+    public function updateBigStrategies(array $bidStrategies): void
+    {
+        try {
+            $this->client->post(
+                self::URI_BID_STRATEGIES,
+                [
+                    RequestOptions::JSON => ['bid_strategies' => $bidStrategies],
+                ]
+            );
+        } catch (RequestException $exception) {
+            throw new UnexpectedClientResponseException(
+                sprintf(
+                    '[ADPAY] Update bid strategies on %s failed (%s).',
+                    $this->client->getConfig()['base_uri'],
+                    $exception->getMessage()
+                ),
+                $exception->getCode(),
+                $exception
+            );
+        }
     }
 
     public function updateCampaign(array $campaigns): void

--- a/app/Client/Mapper/AdPay/DemandBidStrategyMapper.php
+++ b/app/Client/Mapper/AdPay/DemandBidStrategyMapper.php
@@ -20,29 +20,23 @@
 
 declare(strict_types = 1);
 
-namespace Adshares\Demand\Application\Service;
+namespace Adshares\Adserver\Client\Mapper\AdPay;
 
-use Adshares\Demand\Application\Dto\AdPayEvents;
+use Adshares\Adserver\Models\BidStrategy;
+use Illuminate\Support\Collection;
 
-interface AdPay
+class DemandBidStrategyMapper
 {
-    public function updateBigStrategies(array $bidStrategies): void;
-
-    public function updateCampaign(array $campaigns): void;
-
-    public function deleteCampaign(array $campaignIds): void;
-
-    public function addViews(AdPayEvents $events): void;
-
-    public function addClicks(AdPayEvents $events): void;
-
-    public function addConversions(AdPayEvents $events): void;
-
-    public function getPayments(
-        int $timestamp,
-        bool $recalculate = false,
-        bool $force = false,
-        ?int $limit = null,
-        ?int $offset = null
-    ): array;
+    public static function mapBidStrategyCollectionToArray(Collection $bidStrategies): array
+    {
+        return $bidStrategies->map(
+            function (BidStrategy $bidStrategy) {
+                return [
+                    'id' => $bidStrategy->uuid,
+                    'name' => $bidStrategy->name,
+                    'details' => $bidStrategy->bidStrategyDetails->toArray(),
+                ];
+            }
+        )->toArray();
+    }
 }

--- a/app/Client/Mapper/AdPay/DemandCampaignMapper.php
+++ b/app/Client/Mapper/AdPay/DemandCampaignMapper.php
@@ -35,14 +35,14 @@ class DemandCampaignMapper
     {
         return $campaigns->map(
             function (Campaign $campaign) {
-                $campaignArray = $campaign->toArray();
+                $basicInformation = $campaign->basic_information;
 
                 return [
                     'id' => $campaign->uuid,
                     'advertiser_id' => Campaign::fetchAdvertiserId($campaign->id),
-                    'budget' => $campaignArray['basic_information']['budget'],
-                    'max_cpc' => $campaignArray['basic_information']['max_cpc'],
-                    'max_cpm' => $campaignArray['basic_information']['max_cpm'],
+                    'budget' => $basicInformation['budget'],
+                    'max_cpc' => $basicInformation['max_cpc'],
+                    'max_cpm' => $basicInformation['max_cpm'],
                     'time_start' => DateTime::createFromFormat(DateTime::ATOM, $campaign->time_start)->getTimestamp(),
                     'time_end' => null !== $campaign->time_end ? DateTime::createFromFormat(
                         DateTime::ATOM,
@@ -50,7 +50,8 @@ class DemandCampaignMapper
                     )->getTimestamp() : null,
                     'banners' => self::extractBanners($campaign),
                     'conversions' => self::processConversions($campaign->conversions),
-                    'filters' => self::processTargeting($campaignArray['targeting']),
+                    'filters' => self::processTargeting($campaign->targeting),
+                    'bid_strategy_id' => $campaign->bid_strategy_uuid,
                 ];
             }
         )->toArray();

--- a/app/Console/Commands/AdPayCampaignExportCommand.php
+++ b/app/Console/Commands/AdPayCampaignExportCommand.php
@@ -21,20 +21,38 @@ declare(strict_types = 1);
 
 namespace Adshares\Adserver\Console\Commands;
 
+use Adshares\Adserver\Client\Mapper\AdPay\DemandBidStrategyMapper;
 use Adshares\Adserver\Client\Mapper\AdPay\DemandCampaignMapper;
+use Adshares\Adserver\Console\Locker;
+use Adshares\Adserver\Models\BidStrategy;
 use Adshares\Adserver\Models\Campaign;
 use Adshares\Adserver\Models\Config;
 use Adshares\Demand\Application\Service\AdPay;
 use DateTime;
 use function count;
+use function sprintf;
 
 class AdPayCampaignExportCommand extends BaseCommand
 {
+    private const BID_STRATEGY_CHUNK_SIZE = 100;
+
+    private const CAMPAIGN_CHUNK_SIZE = 100;
+
     protected $signature = 'ops:adpay:campaign:export';
 
     protected $description = 'Exports campaign data to AdPay';
 
-    public function handle(AdPay $adPay): void
+    /** @var AdPay */
+    private $adPay;
+
+    public function __construct(Locker $locker, AdPay $adPay)
+    {
+        $this->adPay = $adPay;
+
+        parent::__construct($locker);
+    }
+
+    public function handle(): void
     {
         if (!$this->lock()) {
             $this->info('Command '.$this->signature.' already running');
@@ -44,18 +62,58 @@ class AdPayCampaignExportCommand extends BaseCommand
 
         $this->info('Start command '.$this->signature);
 
+        $this->exportBidStrategies();
+        $this->exportCampaigns();
+
+        $this->info('Finish command '.$this->signature);
+    }
+
+    private function exportBidStrategies(): void
+    {
+        $now = new DateTime();
+        $dateFrom = Config::fetchDateTime(Config::ADPAY_BID_STRATEGY_EXPORT_TIME);
+
+        $offset = 0;
+        $loopCount = 0;
+        do {
+            $bigStrategies = BidStrategy::fetchForExport($dateFrom, self::BID_STRATEGY_CHUNK_SIZE, $offset);
+            $bidStrategiesCount = $bigStrategies->count();
+            $this->info(sprintf('(%d) Found %d bid strategies to export.', ++$loopCount, $bidStrategiesCount));
+
+            if ($bidStrategiesCount > 0) {
+                $this->adPay->updateBigStrategies(
+                    DemandBidStrategyMapper::mapBidStrategyCollectionToArray($bigStrategies)
+                );
+            }
+
+            $offset += $bidStrategiesCount;
+        } while ($bidStrategiesCount === self::BID_STRATEGY_CHUNK_SIZE);
+
+        Config::upsertDateTime(Config::ADPAY_BID_STRATEGY_EXPORT_TIME, $now);
+    }
+
+    private function exportCampaigns(): void
+    {
         $now = new DateTime();
         $dateFrom = Config::fetchDateTime(Config::ADPAY_CAMPAIGN_EXPORT_TIME);
 
-        $updatedCampaigns =
-            Campaign::where('updated_at', '>=', $dateFrom)->where('status', Campaign::STATUS_ACTIVE)->with(
-                'conversions'
-            )->get();
-        $this->info(sprintf('Found %d updated campaigns to export.', count($updatedCampaigns)));
-        if (count($updatedCampaigns) > 0) {
-            $campaigns = DemandCampaignMapper::mapCampaignCollectionToCampaignArray($updatedCampaigns);
-            $adPay->updateCampaign($campaigns);
-        }
+        $offset = 0;
+        $loopCount = 0;
+        do {
+            $updatedCampaigns =
+                Campaign::where('updated_at', '>=', $dateFrom)->where('status', Campaign::STATUS_ACTIVE)->with(
+                    'conversions'
+                )->limit(self::CAMPAIGN_CHUNK_SIZE)->offset($offset)->get();
+            $campaignCount = $updatedCampaigns->count();
+            $this->info(sprintf('(%d) Found %d updated campaigns to export.', ++$loopCount, $campaignCount));
+
+            if ($campaignCount > 0) {
+                $campaigns = DemandCampaignMapper::mapCampaignCollectionToCampaignArray($updatedCampaigns);
+                $this->adPay->updateCampaign($campaigns);
+            }
+
+            $offset += $campaignCount;
+        } while ($campaignCount === self::CAMPAIGN_CHUNK_SIZE);
 
         $deletedCampaigns =
             Campaign::withTrashed()
@@ -65,11 +123,9 @@ class AdPayCampaignExportCommand extends BaseCommand
         $this->info(sprintf('Found %d deleted campaigns to export.', count($deletedCampaigns)));
         if (count($deletedCampaigns) > 0) {
             $campaignIds = DemandCampaignMapper::mapCampaignCollectionToCampaignIds($deletedCampaigns);
-            $adPay->deleteCampaign($campaignIds);
+            $this->adPay->deleteCampaign($campaignIds);
         }
 
         Config::upsertDateTime(Config::ADPAY_CAMPAIGN_EXPORT_TIME, $now);
-
-        $this->info('Finish command '.$this->signature);
     }
 }

--- a/app/Console/Commands/AdSelectInventoryExporterCommand.php
+++ b/app/Console/Commands/AdSelectInventoryExporterCommand.php
@@ -64,9 +64,6 @@ class AdSelectInventoryExporterCommand extends BaseCommand
 
         $this->info('Started exporting inventory to AdSelect.');
 
-        // @todo use it when $from, $to functionality will be implemented
-        // $from = Config::fetchAdSelectInventoryExportTime();
-
         $activeCampaigns = $this->campaignRepository->fetchActiveCampaigns();
         $deletedCampaigns = $this->campaignRepository->fetchCampaignsToDelete();
 

--- a/app/Console/Commands/DemandProcessPayments.php
+++ b/app/Console/Commands/DemandProcessPayments.php
@@ -28,6 +28,7 @@ use Adshares\Common\Exception\InvalidArgumentException;
 use DateTime;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Exception\LogicException;
 
 class DemandProcessPayments extends BaseCommand
@@ -49,7 +50,7 @@ class DemandProcessPayments extends BaseCommand
         $this->info('Start command '.$this->getName());
 
         PaymentReport::fillMissingReports();
-        $lastAvailableTimestamp = $this->getLastAvailableTimestamp();
+        $lastAvailableTimestamp = self::getLastAvailableTimestamp();
         $isRecalculationNeeded = null !== $this->option('ids');
         $reports = $this->fetchPaymentReports();
 
@@ -108,18 +109,9 @@ class DemandProcessPayments extends BaseCommand
                 }
                 $report->setPrepared();
             }
-
-            if ($report->isPrepared()) {
-                try {
-                    Artisan::call(DemandSendPayments::COMMAND_SIGNATURE, [], $this->getOutput());
-                } catch (LogicException $logicException) {
-                    $this->warn(sprintf('Command %s is locked', DemandSendPayments::COMMAND_SIGNATURE));
-
-                    continue;
-                }
-                $report->setDone();
-            }
         }
+
+        $this->sendPayments($reports);
 
         try {
             Artisan::call(
@@ -172,16 +164,50 @@ class DemandProcessPayments extends BaseCommand
         return new DateTime('@'.$timestampFrom);
     }
 
-    private function getLastAvailableTimestamp(): int
+    private static function getLastAvailableTimestamp(): int
     {
-        return $this->getLastExportedEventTimestamp() - PaymentReport::MIN_INTERVAL;
+        return self::getLastExportedEventTimestamp() - PaymentReport::MIN_INTERVAL;
     }
 
-    private function getLastExportedEventTimestamp(): int
+    private static function getLastExportedEventTimestamp(): int
     {
         return min(
             Config::fetchDateTime(Config::ADPAY_LAST_EXPORTED_EVENT_TIME)->getTimestamp(),
             Config::fetchDateTime(Config::ADPAY_LAST_EXPORTED_CONVERSION_TIME)->getTimestamp()
         );
+    }
+
+    private function sendPayments(Collection $reports): void
+    {
+        $preparedReports = $reports->filter(
+            function ($report) {
+                /** @var PaymentReport $report */
+                return $report->isPrepared();
+            }
+        );
+
+        if ($preparedReports->count() === 0) {
+            return;
+        }
+
+        DB::beginTransaction();
+
+        /** @var PaymentReport $report */
+        foreach ($preparedReports as $report) {
+            $report->setDone();
+        }
+
+        try {
+            $sendStatus = Artisan::call(DemandSendPayments::COMMAND_SIGNATURE, [], $this->getOutput());
+
+            if (DemandSendPayments::STATUS_OK === $sendStatus) {
+                DB::commit();
+            } else {
+                DB::rollBack();
+            }
+        } catch (LogicException $logicException) {
+            DB::rollBack();
+            $this->warn(sprintf('Command %s is locked', DemandSendPayments::COMMAND_SIGNATURE));
+        }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -44,8 +44,6 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
     }
 
     /**

--- a/app/Http/Controllers/ClassificationController.php
+++ b/app/Http/Controllers/ClassificationController.php
@@ -22,14 +22,17 @@ namespace Adshares\Adserver\Http\Controllers;
 
 use Adshares\Adserver\Client\ClassifierExternalClient;
 use Adshares\Adserver\Http\Controller;
+use Adshares\Adserver\Mail\BannerClassified;
 use Adshares\Adserver\Models\Banner;
 use Adshares\Adserver\Models\BannerClassification;
+use Adshares\Adserver\Models\User;
 use Adshares\Adserver\Repository\Common\ClassifierExternalRepository;
 use Adshares\Adserver\Services\Common\ClassifierExternalSignatureVerifier;
 use DateTime;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -39,8 +42,12 @@ class ClassificationController extends Controller
 {
     /** @var ClassifierExternalRepository */
     private $classifierRepository;
+
     /** @var ClassifierExternalSignatureVerifier */
     private $signatureVerifier;
+
+    /** @var array */
+    private $notifyUserIds = [];
 
     public function __construct(
         ClassifierExternalRepository $classifierRepository,
@@ -66,6 +73,7 @@ class ClassificationController extends Controller
         $banners = Banner::fetchBannerByPublicIds($bannerPublicIds)->keyBy('uuid');
 
         foreach ($inputs as $input) {
+            /** @var $banner Banner */
             if (null === ($banner = $banners->get($input['id']))
                 || null === ($classification =
                     BannerClassification::fetchByBannerIdAndClassifier($banner->id, $classifier))) {
@@ -155,7 +163,13 @@ class ClassificationController extends Controller
             }
 
             $classification->classified($keywords, $signature, $signedAt);
+            $userId = $banner->campaign->user_id;
+            if (!in_array($userId, $this->notifyUserIds)) {
+                $this->notifyUserIds[] = $userId;
+            }
         }
+
+        $this->sendMails();
 
         if ($isAnySignatureInvalid) {
             return self::json(['message' => 'Invalid signature'], Response::HTTP_UNPROCESSABLE_ENTITY);
@@ -225,6 +239,19 @@ class ClassificationController extends Controller
 
                 throw new UnprocessableEntityHttpException('Missing timestamp');
             }
+        }
+    }
+
+    private function sendMails(): void
+    {
+        if (empty($this->notifyUserIds)) {
+            return;
+        }
+
+        $users = User::fetchByIds($this->notifyUserIds);
+
+        foreach ($users as $user) {
+            Mail::to($user->email)->send(new BannerClassified());
         }
     }
 }

--- a/app/Http/Controllers/Manager/BidStrategyController.php
+++ b/app/Http/Controllers/Manager/BidStrategyController.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types = 1);
+/**
+ * Copyright (c) 2018 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Http\Controllers\Manager;
+
+use Adshares\Adserver\Http\Controller;
+use Adshares\Adserver\Http\Requests\BidStrategyRequest;
+use Adshares\Adserver\Http\Utils;
+use Adshares\Adserver\Models\BidStrategy;
+use Adshares\Adserver\Models\BidStrategyDetail;
+use Adshares\Adserver\Models\Config;
+use Adshares\Adserver\Models\User;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+class BidStrategyController extends Controller
+{
+    public function getBidStrategyUuidDefault(): JsonResponse
+    {
+        return self::json(['uuid' => Config::fetchStringOrFail(Config::BID_STRATEGY_UUID_DEFAULT)]);
+    }
+
+    public function putBidStrategyUuidDefault(Request $request): JsonResponse
+    {
+        $bidStrategyPublicId = $request->input('uuid');
+        if (!Utils::isUuidValid($bidStrategyPublicId)) {
+            throw new UnprocessableEntityHttpException(
+                sprintf('Invalid id (%s)', $bidStrategyPublicId)
+            );
+        }
+
+        $bidStrategy = BidStrategy::fetchByPublicId($bidStrategyPublicId);
+        if (null === $bidStrategy) {
+            throw new NotFoundHttpException(sprintf('BidStrategy (%s) does not exist.', $bidStrategyPublicId));
+        }
+        if (BidStrategy::ADMINISTRATOR_ID !== $bidStrategy->user_id) {
+            throw new HttpException(
+                JsonResponse::HTTP_FORBIDDEN,
+                sprintf('Cannot set bid strategy uuid (%s) as default', $bidStrategyPublicId)
+            );
+        }
+
+        Config::upsertByKey(Config::BID_STRATEGY_UUID_DEFAULT, $bidStrategyPublicId);
+
+        return self::json([], JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    public function getBidStrategy(): JsonResponse
+    {
+        return self::json(BidStrategy::fetchForUser(Auth::user()->id));
+    }
+
+    public function putBidStrategy(BidStrategyRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $isAdmin = $user->isAdmin();
+
+        $input = $request->toArray();
+
+        DB::beginTransaction();
+
+        try {
+            $bidStrategy = BidStrategy::register($input['name'], $isAdmin ? BidStrategy::ADMINISTRATOR_ID : $user->id);
+            $bidStrategyDetails = [];
+            foreach ($input['details'] as $detail) {
+                $bidStrategyDetails[] = BidStrategyDetail::create($detail['category'], (float)$detail['rank']);
+            }
+            $bidStrategy->bidStrategyDetails()->saveMany($bidStrategyDetails);
+
+            DB::commit();
+        } catch (Exception $exception) {
+            DB::rollBack();
+            Log::debug(
+                sprintf('BidStrategy (%s) could not be added (%s).', $input['name'], $exception->getMessage())
+            );
+
+            throw new HttpException(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, 'Cannot add bid strategy');
+        }
+
+        return self::json(['uuid' => $bidStrategy->uuid], JsonResponse::HTTP_CREATED);
+    }
+
+    public function patchBidStrategy(string $bidStrategyPublicId, BidStrategyRequest $request): JsonResponse
+    {
+        if (!Utils::isUuidValid($bidStrategyPublicId)) {
+            throw new UnprocessableEntityHttpException(sprintf('Invalid id (%s)', $bidStrategyPublicId));
+        }
+
+        /** @var User $user */
+        $user = Auth::user();
+        $bidStrategy = BidStrategy::fetchByPublicId($bidStrategyPublicId);
+
+        if (null === $bidStrategy) {
+            throw new NotFoundHttpException(sprintf('BidStrategy (%s) does not exist.', $bidStrategyPublicId));
+        }
+        if ($bidStrategy->user_id !== $user->id
+            && !($bidStrategy->user_id === BidStrategy::ADMINISTRATOR_ID
+                && $user->isAdmin())) {
+            throw new HttpException(
+                JsonResponse::HTTP_UNAUTHORIZED,
+                sprintf('BidStrategy (%s) could not be edited.', $bidStrategyPublicId)
+            );
+        }
+
+        $input = $request->toArray();
+
+        DB::beginTransaction();
+
+        try {
+            $bidStrategy->name = $input['name'];
+            $bidStrategy->save();
+            $bidStrategy->bidStrategyDetails()->delete();
+            $bidStrategyDetails = [];
+            foreach ($input['details'] as $detail) {
+                $bidStrategyDetails[] = BidStrategyDetail::create($detail['category'], (float)$detail['rank']);
+            }
+            $bidStrategy->bidStrategyDetails()->saveMany($bidStrategyDetails);
+
+            DB::commit();
+        } catch (Exception $exception) {
+            DB::rollBack();
+            Log::debug(
+                sprintf('BidStrategy (%s) could not be edited (%s).', $input['name'], $exception->getMessage())
+            );
+
+            throw new HttpException(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, 'Cannot edit bid strategy');
+        }
+
+        return self::json([], JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Manager/CampaignsController.php
+++ b/app/Http/Controllers/Manager/CampaignsController.php
@@ -26,6 +26,8 @@ use Adshares\Adserver\Jobs\ClassifyCampaign;
 use Adshares\Adserver\Models\Banner;
 use Adshares\Adserver\Models\BannerClassification;
 use Adshares\Adserver\Models\Campaign;
+use Adshares\Adserver\Models\Config;
+use Adshares\Adserver\Models\ConfigException;
 use Adshares\Adserver\Models\ConversionDefinition;
 use Adshares\Adserver\Models\Notification;
 use Adshares\Adserver\Repository\CampaignRepository;
@@ -124,7 +126,8 @@ class CampaignsController extends Controller
     {
         try {
             $exchangeRate = $this->exchangeRateReader->fetchExchangeRate();
-        } catch (ExchangeRateNotAvailableException $exception) {
+            $bidStrategyUuid = Config::fetchStringOrFail(Config::BID_STRATEGY_UUID_DEFAULT);
+        } catch (ExchangeRateNotAvailableException|ConfigException $exception) {
             return self::json([], Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
@@ -135,6 +138,7 @@ class CampaignsController extends Controller
 
         $input['basic_information']['status'] = Campaign::STATUS_DRAFT;
         $input['user_id'] = Auth::user()->id;
+        $input['bid_strategy_uuid'] = $bidStrategyUuid;
 
         $campaign = new Campaign($input);
 

--- a/app/Http/Controllers/Manager/SitesController.php
+++ b/app/Http/Controllers/Manager/SitesController.php
@@ -25,6 +25,7 @@ use Adshares\Adserver\Http\Requests\GetSiteCode;
 use Adshares\Adserver\Http\Response\Site\SizesResponse;
 use Adshares\Adserver\Jobs\AdUserRegisterUrl;
 use Adshares\Adserver\Models\Site;
+use Adshares\Adserver\Models\SitesRejectedDomain;
 use Adshares\Adserver\Models\User;
 use Adshares\Adserver\Models\Zone;
 use Adshares\Adserver\Services\Publisher\SiteCodeGenerator;
@@ -41,6 +42,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class SitesController extends Controller
@@ -61,9 +63,8 @@ class SitesController extends Controller
         }
         $url = (string)$request->input('site.url');
         $domain = DomainReader::domain($url);
-        if (!SiteValidator::isDomainValid($domain)) {
-            throw new UnprocessableEntityHttpException('Invalid domain');
-        }
+        self::validateDomain($domain);
+
         $inputZones = $request->input('site.ad_units');
         $this->validateInputZones($inputZones);
 
@@ -138,9 +139,7 @@ class SitesController extends Controller
             }
             $url = (string)$input['url'];
             $domain = DomainReader::domain($url);
-            if (!SiteValidator::isDomainValid($domain)) {
-                throw new UnprocessableEntityHttpException('Invalid domain');
-            }
+            self::validateDomain($domain);
 
             $input['domain'] = $domain;
             $updateDomainAndUrl = $site->domain !== $domain || $site->url !== $url;
@@ -367,6 +366,32 @@ class SitesController extends Controller
             if (!isset($inputZone['size']) || !is_string($inputZone['size']) || !Size::isValid($inputZone['size'])) {
                 throw new UnprocessableEntityHttpException('Invalid size.');
             }
+        }
+    }
+
+    public function verifyDomain(Request $request): JsonResponse
+    {
+        $domain = $request->get('domain');
+        if (null === $domain) {
+            throw new BadRequestHttpException('Field `domain` is required.');
+        }
+        self::validateDomain($domain);
+
+        return self::json(
+            ['code' => Response::HTTP_OK, 'message' => 'Valid domain.'],
+            Response::HTTP_OK
+        );
+    }
+
+    private static function validateDomain(string $domain): void
+    {
+        if (!SiteValidator::isDomainValid($domain)) {
+            throw new UnprocessableEntityHttpException('Invalid domain.');
+        }
+        if (SitesRejectedDomain::isDomainRejected($domain)) {
+            throw new UnprocessableEntityHttpException(
+                'The subdomain '.$domain.' is not supported. Please use your own domain.'
+            );
         }
     }
 }

--- a/app/Http/Requests/BidStrategyRequest.php
+++ b/app/Http/Requests/BidStrategyRequest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Http\Requests;
+
+class BidStrategyRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'details' => 'present|array',
+            'details.*.category' => 'required|string|max:267',
+            'details.*.rank' => 'required|numeric|min:0|max:1',
+        ];
+    }
+
+    public function toArray(): array
+    {
+        return $this->validated();
+    }
+}

--- a/app/Mail/BannerClassified.php
+++ b/app/Mail/BannerClassified.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class BannerClassified extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct()
+    {
+        $this->subject('Advertisement classified');
+    }
+
+    public function build(): Mailable
+    {
+        return $this->markdown('emails.banner-classified');
+    }
+}

--- a/app/Models/BidStrategy.php
+++ b/app/Models/BidStrategy.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Models;
+
+use Adshares\Adserver\Events\GenerateUUID;
+use Adshares\Adserver\Models\Traits\AutomateMutators;
+use Adshares\Adserver\Models\Traits\BinHex;
+use DateTime;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int id
+ * @property string uuid
+ * @property int user_id
+ * @property string name
+ * @property Carbon created_at
+ * @property Carbon updated_at
+ * @property Collection bidStrategyDetails
+ * @property Collection campaigns
+ * @mixin Builder
+ */
+class BidStrategy extends Model
+{
+    use AutomateMutators;
+    use BinHex;
+
+    public const ADMINISTRATOR_ID = 0;
+
+    protected $table = 'bid_strategy';
+
+    protected $appends = [
+        'details',
+    ];
+
+    protected $dispatchesEvents = [
+        'creating' => GenerateUUID::class,
+    ];
+
+    protected $fillable = [
+        'name',
+        'user_id',
+    ];
+
+    protected $traitAutomate = [
+        'uuid' => 'BinHex',
+    ];
+
+    protected $visible = [
+        'details',
+        'name',
+        'uuid',
+    ];
+
+    public static function register(string $name, int $userId): self
+    {
+        $model = new self(
+            [
+                'name' => $name,
+                'user_id' => $userId,
+            ]
+        );
+        $model->save();
+
+        return $model;
+    }
+
+    public static function fetchByPublicId(string $publicId): ?self
+    {
+        return self::where('uuid', hex2bin($publicId))->first();
+    }
+
+    public static function fetchForExport(DateTime $dateFrom, int $limit, int $offset = 0): Collection
+    {
+        return self::where('updated_at', '>=', $dateFrom)->limit($limit)->offset($offset)->get();
+    }
+
+    public static function fetchForUser(int $userId): Collection
+    {
+        return self::whereIn('user_id', [self::ADMINISTRATOR_ID, $userId])->get();
+    }
+
+    public function bidStrategyDetails(): HasMany
+    {
+        return $this->hasMany(BidStrategyDetail::class);
+    }
+
+    public function campaigns(): HasMany
+    {
+        return $this->hasMany(Campaign::class);
+    }
+
+    public function getDetailsAttribute(): Collection
+    {
+        return $this->bidStrategyDetails;
+    }
+}

--- a/app/Models/BidStrategyDetail.php
+++ b/app/Models/BidStrategyDetail.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int id
+ * @property int bid_strategy_id
+ * @property string category
+ * @property float rank
+ * @property BidStrategy bidStrategy
+ * @mixin Builder
+ */
+class BidStrategyDetail extends Model
+{
+    public $timestamps = false;
+
+    protected $casts = [
+        'rank' => 'float',
+    ];
+
+    protected $fillable = [
+        'category',
+        'rank',
+    ];
+
+    protected $visible = [
+        'category',
+        'rank',
+    ];
+
+    protected $touches = [
+        'bidStrategy',
+    ];
+
+    public static function create(string $category, float $rank): self
+    {
+        return new self(
+            [
+                'category' => $category,
+                'rank' => $rank,
+            ]
+        );
+    }
+
+    public function bidStrategy(): BelongsTo
+    {
+        return $this->belongsTo(BidStrategy::class);
+    }
+}

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -63,7 +63,10 @@ use function hex2bin;
  * @property User user
  * @property string secret
  * @property int conversion_click
+ * @property string bid_strategy_uuid
+ * @property array basic_information
  * @property array classifications
+ * @property array targeting
  * @method static Builder where(string $string, int $campaignId)
  * @method static Builder groupBy(string...$groups)
  * @mixin Builder
@@ -130,6 +133,7 @@ class Campaign extends Model
         'classification_status',
         'classification_tags',
         'conversion_click',
+        'bid_strategy_uuid',
     ];
 
     protected $visible = [
@@ -147,12 +151,14 @@ class Campaign extends Model
         'secret',
         'conversion_click',
         'conversion_click_link',
+        'bid_strategy_uuid',
     ];
 
     protected $traitAutomate = [
         'uuid' => 'BinHex',
         'time_start' => 'DateAtom',
         'time_end' => 'DateAtom',
+        'bid_strategy_uuid' => 'BinHex',
     ];
 
     protected $appends = [

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -46,6 +46,10 @@ class Config extends Model
 
     public const LICENCE_ACCOUNT = 'licence-account';
 
+    public const BID_STRATEGY_UUID_DEFAULT = 'bid-strategy-uuid-default';
+
+    public const ADPAY_BID_STRATEGY_EXPORT_TIME = 'adpay-bid-strategy-export';
+
     public const ADPAY_CAMPAIGN_EXPORT_TIME = 'adpay-campaign-export';
 
     public const ADPAY_LAST_EXPORTED_CONVERSION_TIME = 'adpay-last-conversion-time';
@@ -186,7 +190,7 @@ class Config extends Model
         return (string)self::fetchByKeyOrFail($key)->value;
     }
 
-    private static function upsertByKey(string $key, string $value): void
+    public static function upsertByKey(string $key, string $value): void
     {
         $config = self::fetchByKey($key);
 

--- a/app/Models/SitesRejectedDomain.php
+++ b/app/Models/SitesRejectedDomain.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+namespace Adshares\Adserver\Models;
+
+use DateTime;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int id
+ * @property Carbon created_at
+ * @property Carbon updated_at
+ * @property Carbon|null deleted_at
+ * @property string domain
+ * @mixin Builder
+ */
+class SitesRejectedDomain extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'domain',
+    ];
+
+    protected $visible = [
+        'domain',
+    ];
+
+    public static function upsert(string $domain): void
+    {
+        $model = self::where('domain', $domain)->first();
+        if (null === $model) {
+            $model = new self(['domain' => $domain]);
+        } else {
+            $model->updated_at = new DateTime();
+        }
+        $model->save();
+    }
+
+    public static function deleteByIds(array $ids): void
+    {
+        self::whereIn('id', $ids)->delete();
+    }
+
+    public static function fetchAll(): Collection
+    {
+        return self::all();
+    }
+
+    public static function isDomainRejected(string $domain): bool
+    {
+        $domainParts = explode('.', $domain);
+        if (!$domainParts) {
+            return true;
+        }
+        $domainPartsCount = count($domainParts);
+        if ($domainPartsCount < 2) {
+            return false;
+        }
+
+        array_shift($domainParts);
+        --$domainPartsCount;
+
+        $domains = [];
+        for ($i = 0; $i < $domainPartsCount; $i++) {
+            $domains[] = implode('.', $domainParts);
+            array_shift($domainParts);
+        }
+
+        return self::whereIn('domain', $domains)->get()->count() > 0;
+    }
+}

--- a/app/Utilities/SiteValidator.php
+++ b/app/Utilities/SiteValidator.php
@@ -25,6 +25,7 @@ class SiteValidator
     private const DOMAIN_LENGTH_MAX = 255;
 
     private const DOMAIN_PATTERN = '~^
+        (?![.])                                                  # do not allow domains starting with a dot
         ([\pL\pN\pS\-\_\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?)
     $~ixu';
 
@@ -32,6 +33,7 @@ class SiteValidator
 
     private const URL_PATTERN = '~^
         https?://                                                # protocol
+        (?![.])                                                  # do not allow domains starting with a dot
         ([\pL\pN\pS\-\_\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
     $~ixu';
 

--- a/database/factories/CampaignFactory.php
+++ b/database/factories/CampaignFactory.php
@@ -34,5 +34,6 @@ $factory->define(Campaign::class, function (Faker $faker) {
         'targeting_requires' => [],
         'classification_status' => 0,
         'classification_tags' => null,
+        'bid_strategy_uuid' => '00000000000000000000000000000000',
     ];
 });

--- a/database/migrations/2020_05_04_125910_create_bid_strategy_tables.php
+++ b/database/migrations/2020_05_04_125910_create_bid_strategy_tables.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+use Adshares\Adserver\Facades\DB;
+use Adshares\Adserver\Models\BidStrategy;
+use Adshares\Adserver\Models\Config;
+use Adshares\Adserver\Utilities\UuidStringGenerator;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBidStrategyTables extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(
+            'bid_strategy',
+            function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->binary('uuid');
+                $table->bigInteger('user_id')->index();
+                $table->string('name');
+                $table->timestamps();
+
+                $table->index('updated_at');
+            }
+        );
+
+        if (DB::isMySql()) {
+            DB::statement('ALTER TABLE bid_strategy MODIFY uuid VARBINARY(16) NOT NULL');
+        }
+
+        Schema::table(
+            'bid_strategy',
+            function (Blueprint $table) {
+                $table->unique('uuid');
+            }
+        );
+
+        Schema::create(
+            'bid_strategy_details',
+            function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('bid_strategy_id');
+                $table->string('category', 267);
+                $table->decimal('rank', 3, 2);
+                $table->foreign('bid_strategy_id')
+                    ->references('id')
+                    ->on('bid_strategy')
+                    ->onUpdate('RESTRICT')
+                    ->onDelete('CASCADE');
+            }
+        );
+
+        $bidStrategyUuidHexadecimal = UuidStringGenerator::v4();
+        $bidStrategyUuidBinary = hex2bin($bidStrategyUuidHexadecimal);
+        $now = new DateTime();
+        DB::insert(
+            'INSERT INTO bid_strategy (uuid,user_id,name,created_at,updated_at) VALUES (?,?,?,?,?)',
+            [$bidStrategyUuidBinary, BidStrategy::ADMINISTRATOR_ID, 'Server Default', $now, $now]
+        );
+        DB::insert(
+            'INSERT INTO configs (`key`, value, created_at, updated_at) VALUES (?,?,?,?)',
+            [Config::BID_STRATEGY_UUID_DEFAULT, $bidStrategyUuidHexadecimal, $now, $now]
+        );
+
+        Schema::table(
+            'campaigns',
+            function (Blueprint $table) {
+                $table->binary('bid_strategy_uuid');
+            }
+        );
+
+        if (DB::isMySql()) {
+            DB::statement('ALTER TABLE campaigns MODIFY bid_strategy_uuid VARBINARY(16) NOT NULL');
+        }
+        DB::update('UPDATE campaigns SET bid_strategy_uuid=?', [$bidStrategyUuidBinary]);
+        DB::delete('DELETE FROM configs WHERE `key`=?', [Config::ADPAY_CAMPAIGN_EXPORT_TIME]);
+    }
+
+    public function down(): void
+    {
+        Schema::table(
+            'campaigns',
+            function (Blueprint $table) {
+                $table->dropColumn('bid_strategy_uuid');
+            }
+        );
+        DB::delete('DELETE FROM configs WHERE `key`=?', [Config::BID_STRATEGY_UUID_DEFAULT]);
+        Schema::dropIfExists('bid_strategy_details');
+        Schema::dropIfExists('bid_strategy');
+    }
+}

--- a/database/migrations/2020_05_23_131631_create_sites_rejected_domains_table.php
+++ b/database/migrations/2020_05_23_131631_create_sites_rejected_domains_table.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSitesRejectedDomainsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(
+            'sites_rejected_domains',
+            function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->timestamps();
+                $table->softDeletes();
+                $table->string('domain', 255)->unique();
+            }
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sites_rejected_domains');
+    }
+}

--- a/resources/views/emails/banner-classified.blade.php
+++ b/resources/views/emails/banner-classified.blade.php
@@ -1,0 +1,9 @@
+@component('mail::message')
+Hello,
+
+Your advertisement was classified.
+
+Thanks,
+
+{{ config('app.name') }} Team
+@endcomponent

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -48,4 +48,7 @@ Route::middleware([Kernel::ADMIN_ACCESS, Kernel::JSON_API])->group(function () {
     Route::get('publishers', [UsersController::class, 'publishers']);
 
     Route::put('campaigns/bid-strategy/uuid-default', [BidStrategyController::class, 'putBidStrategyUuidDefault']);
+
+    Route::get('rejected-domains', [AdminController::class, 'getRejectedDomains']);
+    Route::put('rejected-domains', [AdminController::class, 'putRejectedDomains']);
 });

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -22,6 +22,7 @@ declare(strict_types = 1);
 
 use Adshares\Adserver\Http\Controllers\Manager\AdminController;
 use Adshares\Adserver\Http\Controllers\Manager\AuthController;
+use Adshares\Adserver\Http\Controllers\Manager\BidStrategyController;
 use Adshares\Adserver\Http\Controllers\Manager\UsersController;
 use Adshares\Adserver\Http\Kernel;
 use Illuminate\Support\Facades\Route;
@@ -45,4 +46,6 @@ Route::middleware([Kernel::ADMIN_ACCESS, Kernel::JSON_API])->group(function () {
 
     Route::get('users', [UsersController::class, 'browse']);
     Route::get('publishers', [UsersController::class, 'publishers']);
+
+    Route::put('campaigns/bid-strategy/uuid-default', [BidStrategyController::class, 'putBidStrategyUuidDefault']);
 });

--- a/routes/manager.php
+++ b/routes/manager.php
@@ -20,6 +20,7 @@
 
 declare(strict_types = 1);
 
+use Adshares\Adserver\Http\Controllers\Manager\BidStrategyController;
 use Adshares\Adserver\Http\Controllers\Manager\CampaignsController;
 use Adshares\Adserver\Http\Controllers\Manager\ClassifierController;
 use Adshares\Adserver\Http\Controllers\Manager\ConfigController;
@@ -33,6 +34,11 @@ use Adshares\Adserver\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware([Kernel::USER_ACCESS, Kernel::JSON_API])->group(function () {
+    Route::get('campaigns/bid-strategy/uuid-default', [BidStrategyController::class, 'getBidStrategyUuidDefault']);
+    Route::get('campaigns/bid-strategy', [BidStrategyController::class, 'getBidStrategy']);
+    Route::put('campaigns/bid-strategy', [BidStrategyController::class, 'putBidStrategy']);
+    Route::patch('campaigns/bid-strategy/{bid_strategy_public_id}', [BidStrategyController::class, 'patchBidStrategy']);
+
     Route::get('campaigns', [CampaignsController::class, 'browse'])
         ->name('app.campaigns.browse');
     Route::get('campaigns/{campaign_id}', [CampaignsController::class, 'read'])

--- a/routes/manager.php
+++ b/routes/manager.php
@@ -62,6 +62,7 @@ Route::middleware([Kernel::USER_ACCESS, Kernel::JSON_API])->group(function () {
     Route::delete('campaigns/{campaign_id}/classify', [CampaignsController::class, 'disableClassify'])
         ->name('app.campaigns.disable_classify');
 
+    Route::post('sites/domain/validate', [SitesController::class, 'verifyDomain']);
     Route::post('sites', [SitesController::class, 'create'])
         ->name('app.sites.add');
     Route::get('sites/sizes/{site_id?}', [SitesController::class, 'readSitesSizes'])

--- a/tests/app/Client/Mapper/AdPay/DemandBidStrategyMapperTest.php
+++ b/tests/app/Client/Mapper/AdPay/DemandBidStrategyMapperTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+declare(strict_types = 1);
+
+namespace Adshares\Adserver\Tests\Client\Mapper\AdPay;
+
+use Adshares\Adserver\Client\Mapper\AdPay\DemandBidStrategyMapper;
+use Adshares\Adserver\Models\BidStrategy;
+use Adshares\Adserver\Models\BidStrategyDetail;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+
+final class DemandBidStrategyMapperTest extends TestCase
+{
+    public function testMapping(): void
+    {
+        $expected = [
+            [
+                'id' => '0123456789abcdef0123456789abcdef',
+                'name' => 'name',
+                'details' => [
+                    [
+                        'category' => 'user:country:st',
+                        'rank' => 0.3,
+                    ],
+                ],
+            ],
+        ];
+
+        $bidStrategyDetail = new BidStrategyDetail();
+        $bidStrategyDetail->category = $expected[0]['details'][0]['category'];
+        $bidStrategyDetail->rank = $expected[0]['details'][0]['rank'];
+        $bidStrategy = new BidStrategy();
+        $bidStrategy->uuid = $expected[0]['id'];
+        $bidStrategy->name = $expected[0]['name'];
+        $bidStrategy->bidStrategyDetails = new Collection([$bidStrategyDetail]);
+        $collection = new Collection([$bidStrategy]);
+
+        self::assertEquals($expected, DemandBidStrategyMapper::mapBidStrategyCollectionToArray($collection));
+    }
+}

--- a/tests/app/Console/Commands/AdPayEventExportCommandTest.php
+++ b/tests/app/Console/Commands/AdPayEventExportCommandTest.php
@@ -42,17 +42,11 @@ class AdPayEventExportCommandTest extends TestCase
 
     public function testEmptyDb(): void
     {
-        $this->app->bind(
-            AdPay::class,
-            function () {
-                $adPay = $this->createMock(AdPay::class);
-                $adPay->expects(self::atLeastOnce())->method('addViews');
-                $adPay->expects(self::atLeastOnce())->method('addClicks');
-                $adPay->expects(self::atLeastOnce())->method('addConversions');
-
-                return $adPay;
-            }
-        );
+        $adPay = $this->createMock(AdPay::class);
+        $adPay->expects(self::atLeastOnce())->method('addViews');
+        $adPay->expects(self::atLeastOnce())->method('addClicks');
+        $adPay->expects(self::atLeastOnce())->method('addConversions');
+        $this->instance(AdPay::class, $adPay);
 
         $this->artisan('ops:adpay:event:export')->assertExitCode(0);
     }
@@ -61,24 +55,17 @@ class AdPayEventExportCommandTest extends TestCase
     {
         $this->bindAdUser();
 
-        $this->app->bind(
-            AdPay::class,
-            function () {
-                $adPay = $this->createMock(AdPay::class);
-
-                $adPay->expects(self::atLeastOnce())->method('addViews')->will(
-                    self::checkEventCount(1)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
-                    self::checkEventCount(0)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
-                    self::checkEventCount(0)
-                );
-
-                return $adPay;
-            }
+        $adPay = $this->createMock(AdPay::class);
+        $adPay->expects(self::atLeastOnce())->method('addViews')->will(
+            self::checkEventCount(1)
         );
+        $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
+            self::checkEventCount(0)
+        );
+        $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
+            self::checkEventCount(0)
+        );
+        $this->instance(AdPay::class, $adPay);
 
         $event = $this->insertEventView();
         $eventDate = $event->created_at->format(DateTime::ATOM);
@@ -99,24 +86,17 @@ class AdPayEventExportCommandTest extends TestCase
     {
         $this->bindAdUser();
 
-        $this->app->bind(
-            AdPay::class,
-            function () {
-                $adPay = $this->createMock(AdPay::class);
-
-                $adPay->expects(self::atLeastOnce())->method('addViews')->will(
-                    self::checkEventCount(0)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
-                    self::checkEventCount(1)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
-                    self::checkEventCount(0)
-                );
-
-                return $adPay;
-            }
+        $adPay = $this->createMock(AdPay::class);
+        $adPay->expects(self::atLeastOnce())->method('addViews')->will(
+            self::checkEventCount(0)
         );
+        $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
+            self::checkEventCount(1)
+        );
+        $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
+            self::checkEventCount(0)
+        );
+        $this->instance(AdPay::class, $adPay);
 
         $event = $this->insertEventClick();
         $eventDate = $event->created_at->format(DateTime::ATOM);
@@ -128,24 +108,17 @@ class AdPayEventExportCommandTest extends TestCase
     {
         $this->bindAdUser();
 
-        $this->app->bind(
-            AdPay::class,
-            function () {
-                $adPay = $this->createMock(AdPay::class);
-
-                $adPay->expects(self::atLeastOnce())->method('addViews')->will(
-                    self::checkEventCount(0)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
-                    self::checkEventCount(0)
-                );
-                $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
-                    self::checkEventCount(1)
-                );
-
-                return $adPay;
-            }
+        $adPay = $this->createMock(AdPay::class);
+        $adPay->expects(self::atLeastOnce())->method('addViews')->will(
+            self::checkEventCount(0)
         );
+        $adPay->expects(self::atLeastOnce())->method('addClicks')->will(
+            self::checkEventCount(0)
+        );
+        $adPay->expects(self::atLeastOnce())->method('addConversions')->will(
+            self::checkEventCount(1)
+        );
+        $this->instance(AdPay::class, $adPay);
 
         $event = $this->insertEventConversion();
         $eventDate = $event->created_at->format(DateTime::ATOM);
@@ -161,17 +134,11 @@ class AdPayEventExportCommandTest extends TestCase
      */
     public function testInvalidOptions(?string $from, ?string $to): void
     {
-        $this->app->bind(
-            AdPay::class,
-            function () {
-                $adPay = $this->createMock(AdPay::class);
-                $adPay->expects(self::never())->method('addViews');
-                $adPay->expects(self::never())->method('addClicks');
-                $adPay->expects(self::never())->method('addConversions');
-
-                return $adPay;
-            }
-        );
+        $adPay = $this->createMock(AdPay::class);
+        $adPay->expects(self::never())->method('addViews');
+        $adPay->expects(self::never())->method('addClicks');
+        $adPay->expects(self::never())->method('addConversions');
+        $this->instance(AdPay::class, $adPay);
 
         $this->artisan('ops:adpay:event:export', ['--from' => $from, '--to' => $to])->assertExitCode(0);
     }

--- a/tests/app/Console/Commands/DemandProcessPaymentsTest.php
+++ b/tests/app/Console/Commands/DemandProcessPaymentsTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+declare(strict_types = 1);
+
+namespace Adshares\Adserver\Tests\Console\Commands;
+
+use Adshares\Adserver\Console\Commands\AdPayGetPayments;
+use Adshares\Adserver\Console\Commands\DemandSendPayments;
+use Adshares\Adserver\Console\Locker;
+use Adshares\Adserver\Models\Config;
+use Adshares\Adserver\Models\PaymentReport;
+use Adshares\Adserver\Tests\Console\TestCase;
+use Adshares\Mock\Console\Kernel as KernelMock;
+use DateTime;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\Console\Exception\LogicException;
+
+class DemandProcessPaymentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SIGNATURE = 'ops:demand:payments:process';
+
+    public function testNoExportedEvents(): void
+    {
+        $this->artisan(self::SIGNATURE)->assertExitCode(0);
+    }
+
+    public function testLock(): void
+    {
+        $lockerMock = $this->createMock(Locker::class);
+        $lockerMock->expects(self::once())->method('lock')->willReturn(false);
+        $this->instance(Locker::class, $lockerMock);
+
+        $this->artisan(self::SIGNATURE)->assertExitCode(0);
+    }
+
+    /**
+     * @dataProvider reportStatusProvider
+     *
+     * @param array $commandReturnValues
+     * @param int $expectedPaymentReportStatus
+     */
+    public function testReportStatus(array $commandReturnValues, int $expectedPaymentReportStatus): void
+    {
+        self::setupExportTime();
+        $this->setupConsoleKernel($commandReturnValues);
+
+        $this->artisan(self::SIGNATURE)->assertExitCode(0);
+
+        self::assertEquals($expectedPaymentReportStatus, PaymentReport::first()->status);
+    }
+
+    public function reportStatusProvider(): array
+    {
+        return [
+            'all ok' => [
+                self::commandValues(),
+                PaymentReport::STATUS_DONE,
+            ],
+            'get locked' => [
+                self::commandValues(['ops:adpay:payments:get' => new LogicException('text-exception')]),
+                PaymentReport::STATUS_NEW,
+            ],
+            'get client exception' => [
+                self::commandValues(['ops:adpay:payments:get' => AdPayGetPayments::STATUS_CLIENT_EXCEPTION]),
+                PaymentReport::STATUS_NEW,
+            ],
+            'get failed' => [
+                self::commandValues(['ops:adpay:payments:get' => AdPayGetPayments::STATUS_REQUEST_FAILED]),
+                PaymentReport::STATUS_ERROR,
+            ],
+            'prepare locked' => [
+                self::commandValues(['ops:demand:payments:prepare' => new LogicException('text-exception')]),
+                PaymentReport::STATUS_UPDATED,
+            ],
+            'send ads error' => [
+                self::commandValues(['ops:demand:payments:send' => DemandSendPayments::STATUS_ERROR_ADS]),
+                PaymentReport::STATUS_PREPARED,
+            ],
+            'send locked' => [
+                self::commandValues(['ops:demand:payments:send' => new LogicException('text-exception')]),
+                PaymentReport::STATUS_PREPARED,
+            ],
+            'aggregate locked' => [
+                self::commandValues(['ops:stats:aggregate:advertiser' => new LogicException('text-exception')]),
+                PaymentReport::STATUS_DONE,
+            ],
+        ];
+    }
+
+    private static function setupExportTime(): void
+    {
+        Config::upsertDateTime(Config::ADPAY_LAST_EXPORTED_EVENT_TIME, new DateTime());
+        Config::upsertDateTime(Config::ADPAY_LAST_EXPORTED_CONVERSION_TIME, new DateTime());
+    }
+
+    private function setupConsoleKernel(array $commandReturnValues): void
+    {
+        $this->app->singleton(Kernel::class, KernelMock::class);
+        $this->app[Kernel::class]->setCommandReturnValues($commandReturnValues);
+    }
+
+    private static function commandValues(array $merge = []): array
+    {
+        return array_merge(
+            [
+                'ops:adpay:payments:get' => 0,
+                'ops:demand:payments:prepare' => 0,
+                'ops:demand:payments:send' => 0,
+                'ops:stats:aggregate:advertiser' => 0,
+            ],
+            $merge
+        );
+    }
+}

--- a/tests/app/Http/Controllers/Manager/BidStrategyControllerTest.php
+++ b/tests/app/Http/Controllers/Manager/BidStrategyControllerTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+declare(strict_types = 1);
+
+namespace Adshares\Adserver\Tests\Http\Controllers\Manager;
+
+use Adshares\Adserver\Models\BidStrategy;
+use Adshares\Adserver\Models\User;
+use Adshares\Adserver\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class BidStrategyControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/campaigns/bid-strategy';
+    private const URI_UUID_GET = '/api/campaigns/bid-strategy/uuid-default';
+    private const URI_UUID_PUT = '/admin/campaigns/bid-strategy/uuid-default';
+
+    private const STRUCTURE_CHECK = [
+        [
+            'uuid',
+            'name',
+            'details' => [
+                '*' => [
+                    'category',
+                    'rank',
+                ],
+            ],
+        ],
+    ];
+
+    private const DATA = [
+        'name' => 'test-name',
+        'details' => [
+            [
+                'category' => 'user:country:us',
+                'rank' => 1,
+            ],
+            [
+                'category' => 'user:country:other',
+                'rank' => 0.2,
+            ],
+        ],
+    ];
+
+    public function testInitialBidStrategy(): void
+    {
+        $this->actingAs(factory(User::class)->create(), 'api');
+
+        $response = $this->getJson(self::URI);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonStructure(self::STRUCTURE_CHECK);
+        $response->assertJsonCount(1);
+    }
+
+    public function testAddBidStrategy(): void
+    {
+        $this->actingAs(factory(User::class)->create(), 'api');
+
+        $responsePut = $this->putJson(self::URI, self::DATA);
+        $responsePut->assertStatus(Response::HTTP_CREATED);
+
+        $responseGet = $this->getJson(self::URI);
+        $responseGet->assertStatus(Response::HTTP_OK);
+        $responseGet->assertJsonStructure(self::STRUCTURE_CHECK);
+        $responseGet->assertJsonCount(2);
+
+        $content = json_decode($responseGet->getContent(), true);
+        $entry = $content[1];
+        self::assertEquals(self::DATA['name'], $entry['name']);
+        self::assertEquals(self::DATA['details'], $entry['details']);
+    }
+
+    public function testEditOwnBidStrategy(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $this->actingAs($user, 'api');
+
+        $bidStrategy = BidStrategy::register('test', $user->id);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $response = $this->patchJson(self::URI.'/'.$bidStrategyPublicId, self::DATA);
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $bidStrategyEdited = BidStrategy::fetchByPublicId($bidStrategyPublicId)->toArray();
+        self::assertEquals(self::DATA['name'], $bidStrategyEdited['name']);
+        self::assertEquals(self::DATA['details'], $bidStrategyEdited['details']);
+    }
+
+    public function testEditAlienBidStrategy(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $this->actingAs($user, 'api');
+
+        $bidStrategy = BidStrategy::register('test', $user->id + 1);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $response = $this->patchJson(self::URI.'/'.$bidStrategyPublicId, self::DATA);
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testEditNotExistingBidStrategy(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $this->actingAs($user, 'api');
+
+        $bidStrategyPublicId = '0123456789abcdef0123456789abcdef';
+
+        $response = $this->patchJson(self::URI.'/'.$bidStrategyPublicId, self::DATA);
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testEditInvalidBidStrategy(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $this->actingAs($user, 'api');
+
+        $bidStrategyInvalidPublicId = 1000;
+
+        $response = $this->patchJson(self::URI.'/'.$bidStrategyInvalidPublicId, self::DATA);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testDbConnectionErrorWhileAddingBidStrategy(): void
+    {
+        DB::shouldReceive('beginTransaction')->andReturnUndefined();
+        DB::shouldReceive('commit')->andThrow(new RuntimeException());
+        DB::shouldReceive('rollback')->andReturnUndefined();
+
+        $this->actingAs(factory(User::class)->create(), 'api');
+
+        $response = $this->putJson(self::URI, self::DATA);
+        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    public function testDbConnectionErrorWhileEditingBidStrategy(): void
+    {
+        DB::shouldReceive('beginTransaction')->andReturnUndefined();
+        DB::shouldReceive('commit')->andThrow(new RuntimeException());
+        DB::shouldReceive('rollback')->andReturnUndefined();
+
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $this->actingAs($user, 'api');
+
+        $bidStrategy = BidStrategy::register('test', $user->id);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $response = $this->patchJson(self::URI.'/'.$bidStrategyPublicId, self::DATA);
+        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * @dataProvider invalidBidStrategyDataProvider
+     *
+     * @param array $data
+     */
+    public function testAddingBidStrategyInvalid(array $data): void
+    {
+        $this->actingAs(factory(User::class)->create(), 'api');
+
+        $response = $this->putJson(self::URI, $data);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function invalidBidStrategyDataProvider(): array
+    {
+        return [
+            'empty-name' => [
+                [
+                    'name' => '',
+                    'details' => [
+                        [
+                            'category' => 'user:country:us',
+                            'rank' => 0.1,
+                        ],
+                    ],
+                ],
+            ],
+            'rank-too-low' => [
+                [
+                    'name' => 'test-name',
+                    'details' => [
+                        [
+                            'category' => 'user:country:us',
+                            'rank' => -0.1,
+                        ],
+                    ],
+                ],
+            ],
+            'rank-too-high' => [
+                [
+                    'name' => 'test-name',
+                    'details' => [
+                        [
+                            'category' => 'user:country:us',
+                            'rank' => 2,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testGetDefaultUuid(): void
+    {
+        $this->actingAs(factory(User::class)->create(), 'api');
+
+        $response = $this->getJson(self::URI_UUID_GET);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonStructure(['uuid']);
+    }
+
+    public function testPutDefaultUuidValid(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create(['is_admin' => 1]);
+        $this->actingAs($user, 'api');
+        $bidStrategy = BidStrategy::register('test', BidStrategy::ADMINISTRATOR_ID);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $responsePut = $this->put(self::URI_UUID_PUT, ['uuid' => $bidStrategyPublicId]);
+        $responsePut->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $responseGet = $this->getJson(self::URI_UUID_GET);
+        $responseGet->assertStatus(Response::HTTP_OK);
+        $responseGet->assertJsonStructure(['uuid']);
+        self::assertEquals($bidStrategyPublicId, $responseGet->json('uuid'));
+    }
+
+    public function testPutDefaultUuidInvalid(): void
+    {
+        $this->actingAs(factory(User::class)->create(['is_admin' => 1]), 'api');
+
+        $response = $this->put(self::URI_UUID_PUT, ['uuid' => '1234']);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testPutDefaultUuidNotExisting(): void
+    {
+        $this->actingAs(factory(User::class)->create(['is_admin' => 1]), 'api');
+
+        $response = $this->put(self::URI_UUID_PUT, ['uuid' => '00000000000000000000000000000000']);
+
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testPutDefaultUuidForbidden(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create(['is_admin' => 0]);
+        $this->actingAs($user, 'api');
+        $bidStrategy = BidStrategy::register('test', $user->id);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $response = $this->put(self::URI_UUID_PUT, ['uuid' => $bidStrategyPublicId]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testPutDefaultUuidOtherUser(): void
+    {
+        /** @var User $userAdmin */
+        $userAdmin = factory(User::class)->create(['is_admin' => 1]);
+        $this->actingAs($userAdmin, 'api');
+        /** @var User $userOther */
+        $userOther = factory(User::class)->create(['is_admin' => 0]);
+        $bidStrategy = BidStrategy::register('test', $userOther->id);
+        $bidStrategyPublicId = $bidStrategy->uuid;
+
+        $response = $this->put(self::URI_UUID_PUT, ['uuid' => $bidStrategyPublicId]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+}

--- a/tests/app/Http/Controllers/Manager/CampaignsControllerTest.php
+++ b/tests/app/Http/Controllers/Manager/CampaignsControllerTest.php
@@ -263,9 +263,9 @@ final class CampaignsControllerTest extends TestCase
     public function budgetVsResponseWhenCreatingCampaign(): array
     {
         return [
-            [1e11, Response::HTTP_CREATED],
-            [0, Response::HTTP_CREATED],
-            [-11, Response::HTTP_BAD_REQUEST],
+            'positive budget' => [1e11, Response::HTTP_CREATED],
+            'no budget' => [0, Response::HTTP_CREATED],
+            'negative budget' => [-11, Response::HTTP_BAD_REQUEST],
         ];
     }
 

--- a/tests/app/Utilities/AdsUtilsTest.php
+++ b/tests/app/Utilities/AdsUtilsTest.php
@@ -23,6 +23,7 @@ namespace Adshares\Adserver\Tests\Utilities;
 
 use Adshares\Adserver\Utilities\AdsUtils;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class AdsUtilsTest extends TestCase
 {
@@ -95,5 +96,77 @@ final class AdsUtilsTest extends TestCase
             ['0001-00000000-XXXX', '0002-00000000-XXXX', 860402936314359351, 860402936314358],
             ['0001-00000000-XXXX', '0002-00000000-XXXX', 1505185149556105113, 1505185149556104],
         ];
+    }
+
+    public function testEncodeTxId(): void
+    {
+        $input = '00010000F01F0001';
+        $expected = '0001:0000F01F:0001';
+
+        self::assertEquals($expected, AdsUtils::encodeTxId($input));
+    }
+
+    public function testDecodeTxId(): void
+    {
+        $input = '0001:0000F01F:0001';
+        $expected = '00010000F01F0001';
+
+        self::assertEquals($expected, AdsUtils::decodeTxId($input));
+    }
+
+    public function testDecodeTxIdInvalid(): void
+    {
+        $input = 'invalid';
+
+        self::assertNull(AdsUtils::decodeTxId($input));
+    }
+
+    public function testDecodeAddress(): void
+    {
+        $input = '0001-00000028-3E05';
+        $expected = '000100000028';
+
+        self::assertEquals($expected, AdsUtils::decodeAddress($input));
+    }
+
+    public function testDecodeAddressInvalid(): void
+    {
+        $input = 'invalid';
+
+        self::assertNull(AdsUtils::decodeAddress($input));
+    }
+
+    public function testNormalizeAddress(): void
+    {
+        $input = '0001000000283E05';
+        $expected = '0001-00000028-3E05';
+
+        self::assertEquals($expected, AdsUtils::normalizeAddress($input));
+    }
+
+    public function testNormalizeAddressInvalid(): void
+    {
+        $input = 'invalid';
+
+        $this->expectException(RuntimeException::class);
+
+        AdsUtils::normalizeAddress($input);
+    }
+
+    public function testNormalizeTxid(): void
+    {
+        $input = '00010000F01F0001';
+        $expected = '0001:0000F01F:0001';
+
+        self::assertEquals($expected, AdsUtils::normalizeTxid($input));
+    }
+
+    public function testNormalizeTxidInvalid(): void
+    {
+        $input = 'invalid';
+
+        $this->expectException(RuntimeException::class);
+
+        AdsUtils::normalizeTxid($input);
     }
 }

--- a/tests/app/Utilities/SiteValidatorTest.php
+++ b/tests/app/Utilities/SiteValidatorTest.php
@@ -91,6 +91,8 @@ class SiteValidatorTest extends TestCase
             ['https://login@example.com'],
             ['https://login:password@example.com'],
             ['https://example.com:8080'],
+            ['https://.e.com'],
+            ['https://.example.com'],
         ];
     }
 
@@ -98,6 +100,7 @@ class SiteValidatorTest extends TestCase
     {
         return [
             ['com'],
+            ['e.com'],
             ['example.com'],
             ['app.example.com'],
             ['www.app.example.com'],
@@ -119,6 +122,8 @@ class SiteValidatorTest extends TestCase
             ['https://example.com/path?query=true#fragment'],
             ['login@example.com'],
             ['login:password@example.com'],
+            ['.e.com'],
+            ['.example.com'],
         ];
     }
 }

--- a/tests/app/Utilities/UniqueIdTest.php
+++ b/tests/app/Utilities/UniqueIdTest.php
@@ -64,4 +64,26 @@ class UniqueIdTest extends TestCase
 
         UniqueIdentifierFactory::fromString('invalid uuid');
     }
+
+    /** @test */
+    public function equals(): void
+    {
+        $uuid = 'b355a5ac-09cb-45d6-9f75-5dd298b3b862';
+        $uniqueId1 = UniqueIdentifierFactory::fromString($uuid);
+        $uniqueId2 = UniqueIdentifierFactory::fromString($uuid);
+
+        self::assertTrue($uniqueId1->equals($uniqueId1));
+        self::assertTrue($uniqueId1->equals($uniqueId2));
+        self::assertTrue($uniqueId2->equals($uniqueId1));
+    }
+
+    /** @test */
+    public function notEquals(): void
+    {
+        $uniqueId1 = UniqueIdentifierFactory::fromString('b355a5ac-09cb-45d6-9f75-5dd298b3b862');
+        $uniqueId2 = UniqueIdentifierFactory::fromString('a355a5ac-09cb-45d6-9f75-5dd298b3b863');
+
+        self::assertFalse($uniqueId1->equals($uniqueId2));
+        self::assertFalse($uniqueId2->equals($uniqueId1));
+    }
 }

--- a/tests/mock/Console/Kernel.php
+++ b/tests/mock/Console/Kernel.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2018-2019 Adshares sp. z o.o.
+ *
+ * This file is part of AdServer
+ *
+ * AdServer is free software: you can redistribute and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * AdServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AdServer. If not, see <https://www.gnu.org/licenses/>
+ */
+
+declare(strict_types = 1);
+
+namespace Adshares\Mock\Console;
+
+use Adshares\Adserver\Console\Kernel as ConsoleKernel;
+use Exception;
+
+class Kernel extends ConsoleKernel
+{
+    private $commandReturnValues = [];
+    
+    public function call($command, array $parameters = [], $outputBuffer = null)
+    {
+        if (isset($this->commandReturnValues[$command])) {
+            $value = $this->commandReturnValues[$command];
+            if ($value instanceof Exception) {
+                throw $value;
+            }
+
+            return $value;
+        }
+
+        $this->bootstrap();
+
+        return $this->getArtisan()->call($command, $parameters, $outputBuffer);
+    }
+
+    public function setCommandReturnValues(array $values): array
+    {
+        return $this->commandReturnValues = $values;
+    }
+}


### PR DESCRIPTION
Should be deployed with adpay and adpanel.

migration and queue restart required

- Add bid strategy
- Add rejecting site's domains
- Retry payments after ads error
- Email notification after ads classification 