### PR TITLE
Use invoice currencies from config

### DIFF
--- a/app/Http/Controllers/Manager/InvoicesController.php
+++ b/app/Http/Controllers/Manager/InvoicesController.php
@@ -67,7 +67,7 @@ class InvoicesController extends Controller
 
         $input['user_id'] = $user->id;
         Validator::make($input, Invoice::$rules)->validate();
-        if (!in_array($input['currency'] ?? '', explode(',', Config::fetchStringOrFail(Config::INVOICE_CURRENCIES)))) {
+        if (!in_array($input['currency'] ?? '', config('app.invoice_currencies'))) {
             throw new UnprocessableEntityHttpException('Unsupported currency');
         }
         $invoice = Invoice::createProforma($input);

--- a/app/Http/Controllers/Manager/WalletController.php
+++ b/app/Http/Controllers/Manager/WalletController.php
@@ -505,7 +505,7 @@ class WalletController extends Controller
         $fiatDeposit = Config::isTrueOnly(Config::INVOICE_ENABLED) ? [
             'minAmount' => config('app.fiat_deposit_min_amount'),
             'maxAmount' => config('app.fiat_deposit_max_amount'),
-            'currencies' => explode(',', Config::fetchStringOrFail(Config::INVOICE_CURRENCIES)),
+            'currencies' => config('app.invoice_currencies'),
         ] : null;
 
         $message = str_pad($uuid, 64, '0', STR_PAD_LEFT);

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -221,6 +221,7 @@ class Config extends Model
         self::HOT_WALLET_MIN_VALUE => ConfigTypes::Integer,
         self::INVENTORY_EXPORT_WHITELIST => ConfigTypes::Array,
         self::INVENTORY_IMPORT_WHITELIST => ConfigTypes::Array,
+        self::INVOICE_CURRENCIES => ConfigTypes::Array,
         self::INVOICE_ENABLED => ConfigTypes::Bool,
         self::MAX_PAGE_ZONES => ConfigTypes::Integer,
         self::NETWORK_DATA_CACHE_TTL => ConfigTypes::Integer,

--- a/tests/app/Http/Controllers/WalletControllerTest.php
+++ b/tests/app/Http/Controllers/WalletControllerTest.php
@@ -517,8 +517,7 @@ class WalletControllerTest extends TestCase
 
     public function testDepositInfo(): void
     {
-        $user = User::factory()->create();
-        $this->actingAs($user, 'api');
+        $user = $this->login();
         $response = $this->get('/api/deposit-info');
 
         $response->assertStatus(Response::HTTP_OK)->assertJson(['address' => config('app.adshares_address')]);
@@ -534,6 +533,20 @@ class WalletControllerTest extends TestCase
 
         // check value
         $this->assertNotFalse(strpos($message, $user->uuid));
+    }
+
+    public function testDepositInfoWithFiat(): void
+    {
+        Config::updateAdminSettings([Config::INVOICE_ENABLED => '1']);
+        $this->login();
+        $response = $this->get('/api/deposit-info');
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['fiat' => [
+            'minAmount' => 2000,
+            'maxAmount' => 100000,
+            'currencies' => ['EUR', 'USD'],
+        ]]);
     }
 
     public function testHistory(): void


### PR DESCRIPTION
During `WalletController` tests I found out that fetching invoice currencies can be refactored.